### PR TITLE
core cleanups: totality fail-closed, in-place reuse for signed, rewrite_graph

### DIFF
--- a/corgi/NOTES.md
+++ b/corgi/NOTES.md
@@ -119,6 +119,12 @@ reasons. Adding a structural op means either filling a hole (and writing its law
   level is always 1:1.
 - **Leaves are immutable Arc, cloned by refcount; eval moves to last use.** The last reader holds the
   sole Arc, so `into_*` move the buffer and pointwise ops are able to mutate in place (`AddU64` does).
+  *Reuse policy:* an op that is elementwise AND same-width (`AddU64`/`Shr`/`And`, `bin_into`, `neg_into`,
+  `lane_pick`, `xor_signbit`, the in-place fold scatter) consumes its operand and rewrites it under
+  `Arc::get_mut`/`make_mut` when uniquely owned — take the reuse wherever the shape allows. The
+  fresh-allocating leaf ops (`gather`/`gather_lanes` = permutation, `cast` = re-width, `rel`/`cmp_idx`/
+  `sort_block` = a differently-typed result) allocate *by necessity*, not oversight — the access pattern
+  or output type rules reuse out. (Cross-op intermediate elimination is the separate DPS backlog item.)
 - **`Fold`/`FoldScan` are cross-row lockstep, `O(total elements)`.** A general (non-associative) fold is
   sequential *within* a row but vectorized *across* rows: round `t` folds in every still-active row's
   `t`-th element in one body call, so `#rounds = the longest row`, not the element count. The active

--- a/corgi/src/ops/core.rs
+++ b/corgi/src/ops/core.rs
@@ -1004,4 +1004,23 @@ impl<L: OpLike> Op<L> {
             _ => Vec::new(),
         }
     }
+
+    /// the surface name of the UNCHECKED tier, for the ops whose in-bounds precondition no static gate
+    /// proves (`check_total` reports these); `None` for every total/gated/structural op. The match is
+    /// EXHAUSTIVE on purpose: a new `Op` must classify itself here, so the totality guarantee can't
+    /// silently regress (the old `_ => {}` in `check_total` let a new partial op pass as total).
+    pub(crate) fn unchecked_site(&self) -> Option<&'static str> {
+        match self {
+            // data-dependent bounds, no static proof — the `_uns` kernels (`head_uns` lowers to `Get`):
+            Op::Get => Some("get_uns"),
+            Op::Gather => Some("gather_uns"),
+            Op::Slices => Some("slices_uns"),
+            // total (run to a value), gated (lengths/ranges prove the precondition), or pure structural:
+            Op::Field(_) | Op::Lit(_) | Op::Transpose | Op::Zip | Op::TryZip | Op::Unweave
+            | Op::Weave | Op::CapList | Op::CapSum | Op::Cast(_) | Op::Filter | Op::Branch(_)
+            | Op::TryBranch(_) | Op::Unwrap | Op::Inject(_, _) | Op::MapList(_) | Op::Fold(_)
+            | Op::FoldScan(_) | Op::MapSum(_) | Op::GetTry | Op::GatherTry | Op::Flatten
+            | Op::Enlist | Op::Iota | Op::Unit | Op::Select => None,
+        }
+    }
 }

--- a/corgi/src/optimize.rs
+++ b/corgi/src/optimize.rs
@@ -25,6 +25,43 @@ fn map_kind(kind: &NodeKind<NumOp>, f: fn(&Graph<NumOp>) -> Graph<NumOp>) -> Nod
     }
 }
 
+/// the outcome of a rewrite rule at one node (see [`rewrite_graph`]); `None` (the common case) rebuilds
+/// the node verbatim.
+enum Rewrite {
+    Redirect(usize),      // this node already exists (an earlier built id) — point consumers there
+    Replace(Node<NumOp>), // emit this node instead of the default `{ kind, inputs }`
+}
+
+/// the shared single-pass rewriter that `peephole`/`cancel_isos`/`fuse_maps` are each just a `rule` of:
+/// walk nodes in order, remap every edge to its already-rebuilt id, recurse each body via `map_kind`,
+/// then consult `rule` (which sees the body-recursed `kind`, the remapped `inputs`, the nodes `built`
+/// so far, and the original `node`). No hit rebuilds verbatim. (`cse`/`dce` carry cross-node state — a
+/// dedup map, a reachability mark — so they stay bespoke.)
+fn rewrite_graph(
+    g: &Graph<NumOp>,
+    recurse: fn(&Graph<NumOp>) -> Graph<NumOp>,
+    rule: impl Fn(&NodeKind<NumOp>, &[usize], &[Node<NumOp>], &Node<NumOp>) -> Option<Rewrite>,
+) -> Graph<NumOp> {
+    let mut remap = vec![0usize; g.nodes.len()];
+    let mut built: Vec<Node<NumOp>> = Vec::new();
+    for (old, node) in g.nodes.iter().enumerate() {
+        let inputs: Vec<usize> = node.inputs.iter().map(|&i| remap[i]).collect();
+        let kind = map_kind(&node.kind, recurse);
+        remap[old] = match rule(&kind, &inputs, &built, node) {
+            Some(Rewrite::Redirect(r)) => r,
+            Some(Rewrite::Replace(n)) => {
+                built.push(n);
+                built.len() - 1
+            }
+            None => {
+                built.push(Node { kind, inputs });
+                built.len() - 1
+            }
+        };
+    }
+    Graph { nodes: built, output: remap[g.output] }
+}
+
 /// hash-consing: fold structurally-identical nodes into one.
 pub fn cse(g: &Graph<NumOp>) -> Graph<NumOp> {
     let mut new_nodes: Vec<Node<NumOp>> = Vec::new();
@@ -72,21 +109,14 @@ pub fn dce(g: &Graph<NumOp>) -> Graph<NumOp> {
 
 /// peephole: `Field(i)` applied to a `Tuple` is just the tuple's i-th input.
 pub fn peephole(g: &Graph<NumOp>) -> Graph<NumOp> {
-    let mut remap = vec![0usize; g.nodes.len()];
-    let mut new_nodes: Vec<Node<NumOp>> = Vec::new();
-    for (old, node) in g.nodes.iter().enumerate() {
-        let inputs: Vec<usize> = node.inputs.iter().map(|&i| remap[i]).collect();
-        if let NodeKind::Op(NumOp::Core(Op::Field(i))) = &node.kind {
-            let src = inputs[0];
-            if matches!(new_nodes[src].kind, NodeKind::Tuple) {
-                remap[old] = new_nodes[src].inputs[*i];
-                continue;
+    rewrite_graph(g, peephole, |kind, inputs, built, _| {
+        if let NodeKind::Op(NumOp::Core(Op::Field(i))) = kind {
+            if matches!(built[inputs[0]].kind, NodeKind::Tuple) {
+                return Some(Rewrite::Redirect(built[inputs[0]].inputs[*i]));
             }
         }
-        remap[old] = new_nodes.len();
-        new_nodes.push(Node { kind: map_kind(&node.kind, peephole), inputs });
-    }
-    Graph { nodes: new_nodes, output: remap[g.output] }
+        None
+    })
 }
 
 /// inline `g1: A -> B` into `g2: B -> C`, returning `g1 ; g2 : A -> C`. `g2`'s `Input` is replaced by
@@ -120,37 +150,20 @@ pub fn fuse_maps(g: &Graph<NumOp>) -> Graph<NumOp> {
         }
     }
     uses[g.output] += 1;
-
-    let mut remap = vec![0usize; g.nodes.len()];
-    let mut new_nodes: Vec<Node<NumOp>> = Vec::new();
-    for (old, node) in g.nodes.iter().enumerate() {
-        let inputs: Vec<usize> = node.inputs.iter().map(|&i| remap[i]).collect();
-        let kind = map_kind(&node.kind, fuse_maps); // fuse the body's own chains first
-        if let NodeKind::Op(NumOp::Core(Op::MapList(b2))) = &kind {
-            // the producer is a MapList used nowhere else → safe to fold the two bodies into one pass.
-            let fused = if uses[node.inputs[0]] == 1 {
-                match &new_nodes[inputs[0]].kind {
-                    NodeKind::Op(NumOp::Core(Op::MapList(b1))) => {
-                        Some((compose(b1, b2), new_nodes[inputs[0]].inputs[0]))
-                    }
-                    _ => None,
+    rewrite_graph(g, fuse_maps, |kind, inputs, built, node| {
+        if let NodeKind::Op(NumOp::Core(Op::MapList(b2))) = kind {
+            // fuse only when the producer is a MapList used NOWHERE else (else fusing duplicates work).
+            if uses[node.inputs[0]] == 1 {
+                if let NodeKind::Op(NumOp::Core(Op::MapList(b1))) = &built[inputs[0]].kind {
+                    return Some(Rewrite::Replace(Node {
+                        kind: NodeKind::Op(NumOp::Core(Op::MapList(Box::new(compose(b1, b2))))),
+                        inputs: vec![built[inputs[0]].inputs[0]],
+                    }));
                 }
-            } else {
-                None
-            };
-            if let Some((body, producer)) = fused {
-                remap[old] = new_nodes.len();
-                new_nodes.push(Node {
-                    kind: NodeKind::Op(NumOp::Core(Op::MapList(Box::new(body)))),
-                    inputs: vec![producer],
-                });
-                continue;
             }
         }
-        remap[old] = new_nodes.len();
-        new_nodes.push(Node { kind, inputs });
-    }
-    Graph { nodes: new_nodes, output: remap[g.output] }
+        None
+    })
 }
 
 /// adjacent structural isos that are exact inverses (`Zip∘Transpose`, `Weave∘Unweave`, and their
@@ -166,23 +179,16 @@ fn is_inverse(outer: &Op<NumOp>, inner: &Op<NumOp>) -> bool {
 
 /// cancel adjacent inverse isos (see [`is_inverse`]). The iso analogue of `peephole`'s Field-of-Tuple.
 pub fn cancel_isos(g: &Graph<NumOp>) -> Graph<NumOp> {
-    let mut remap = vec![0usize; g.nodes.len()];
-    let mut new_nodes: Vec<Node<NumOp>> = Vec::new();
-    for (old, node) in g.nodes.iter().enumerate() {
-        let inputs: Vec<usize> = node.inputs.iter().map(|&i| remap[i]).collect();
-        let kind = map_kind(&node.kind, cancel_isos);
-        if let NodeKind::Op(NumOp::Core(outer)) = &kind {
-            if let NodeKind::Op(NumOp::Core(inner)) = &new_nodes[inputs[0]].kind {
+    rewrite_graph(g, cancel_isos, |kind, inputs, built, _| {
+        if let NodeKind::Op(NumOp::Core(outer)) = kind {
+            if let NodeKind::Op(NumOp::Core(inner)) = &built[inputs[0]].kind {
                 if is_inverse(outer, inner) {
-                    remap[old] = new_nodes[inputs[0]].inputs[0];
-                    continue;
+                    return Some(Rewrite::Redirect(built[inputs[0]].inputs[0]));
                 }
             }
         }
-        remap[old] = new_nodes.len();
-        new_nodes.push(Node { kind, inputs });
-    }
-    Graph { nodes: new_nodes, output: remap[g.output] }
+        None
+    })
 }
 
 /// run the passes together: peephole and iso-cancellation expose dead/foldable structure, map fusion

--- a/corgi/src/total.rs
+++ b/corgi/src/total.rs
@@ -8,7 +8,7 @@
 //! still has only the unchecked tier.
 
 use crate::graph::{Graph, NodeKind, OpLike};
-use crate::ops::{NumOp, Op};
+use crate::ops::NumOp;
 
 /// `Ok(())` iff the graph (and every body sub-graph) is in the guaranteed-total subset; otherwise the
 /// names of the unchecked-tier ops it uses, in node order.
@@ -25,11 +25,12 @@ pub fn check_total(g: &Graph<NumOp>) -> Result<(), Vec<&'static str>> {
 fn scan(g: &Graph<NumOp>, sites: &mut Vec<&'static str>) {
     for node in &g.nodes {
         let NodeKind::Op(op) = &node.kind else { continue };
-        match op {
-            NumOp::Core(Op::Get) => sites.push("get_uns"), // also `head_uns`, which lowers to `get_uns 0`
-            NumOp::Core(Op::Gather) => sites.push("gather_uns"),
-            NumOp::Core(Op::Slices) => sites.push("slices_uns"),
-            _ => {}
+        // only Core carries the unchecked kernels; each Core op self-reports its tier (`unchecked_site`
+        // is exhaustive, so a new op can't slip through as total). The other buckets are total.
+        if let NumOp::Core(c) = op {
+            if let Some(site) = c.unchecked_site() {
+                sites.push(site);
+            }
         }
         for child in op.children() {
             scan(child, sites); // a kernel op inside a map/fold/scan body counts too

--- a/corgi/src/value.rs
+++ b/corgi/src/value.rs
@@ -102,11 +102,18 @@ macro_rules! prim {
             /// XOR the top (sign) bit of every element, at this width — the order-preserving signed
             /// swizzle (`enc_i64` generalized), an involution. Converts an unsigned column to the
             /// signed encoding of the same non-negative values and back; the numeric layer's `signed`.
-            pub(crate) fn xor_signbit(&self) -> Prim {
+            /// CONSUMES self and rewrites in place when uniquely owned (same elementwise/same-width
+            /// shape as `bin_into`/`neg_into`/`lane_pick` — reuse where we can; see the policy note).
+            pub(crate) fn xor_signbit(self) -> Prim {
                 match self {
-                    $( Prim::$V(v) => {
+                    $( Prim::$V(mut v) => {
                         let m = !(<$t>::MAX >> 1);
-                        Prim::$V(Arc::new(v.iter().map(|&x| x ^ m).collect()))
+                        Prim::$V(if let Some(dst) = Arc::get_mut(&mut v) {
+                            for x in dst.iter_mut() { *x ^= m; }
+                            v
+                        } else {
+                            Arc::new(v.iter().map(|&x| x ^ m).collect())
+                        })
                     } )+
                 }
             }


### PR DESCRIPTION
Three small post-merge cleanups from the codebase-simplification pass.

**1. Totality fail-closed.** `check_total`'s `_ => {}` let a newly-added partial op silently pass as total. The unchecked-tier classification moves to an exhaustive `Op::unchecked_site()` — a new `Op` must now classify itself or the build breaks. (`lengths`/`ranges` already fail *safe* via their fresh/⊤ defaults; `total.rs` was the lone fail-open.)

**2. Recover in-place reuse for `signed`.** `xor_signbit` was the lone elementwise/same-width leaf op still allocating fresh; it now rewrites a uniquely-owned buffer in place under `Arc::get_mut`, like `bin_into`/`neg_into`/`lane_pick`. NOTES documents the allocate-vs-reuse policy (permutation/rewidth/new-output ops allocate by necessity, not oversight).

**3. `rewrite_graph` combinator.** `peephole`/`cancel_isos`/`fuse_maps` each open-coded the same single-pass walk (remap edges, recurse bodies via `map_kind`, special-case one rule, rebuild). Factored into one `rewrite_graph(g, recurse, rule)`; each pass is now just its `Rewrite` rule. Behavior identical — the optimize suite semantic-checks every corpus program. `cse`/`dce` stay bespoke (cross-node state).

All 12 suites green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)