### PR TITLE
corgi: land the arrange API — columnar primitives for a differential-dataflow substrate

### DIFF
--- a/corgi/src/lib.rs
+++ b/corgi/src/lib.rs
@@ -45,7 +45,7 @@ pub use value::{show, Bounds, Value};
 /// to rows. Thin public wrappers over the internal `engine`/`ops::cmp::order` machinery. Added
 /// for the dd-corgi backend spike (Route B: cursor-less corgi arrangement).
 pub mod arrange {
-    use crate::value::{Bounds, Value};
+    use crate::value::{Bounds, Prim, Value};
     use std::cmp::Ordering;
 
     /// Batched equal-range probe (`find` as a single-row batch): for each row of `needles` (any
@@ -89,5 +89,210 @@ pub mod arrange {
     /// pairs in one pass). Use `ia=0..n-1`, `ib=1..n` to flag adjacent-equal runs after a sort.
     pub fn compare_idx(a: &Value, b: &Value, ia: &[usize], ib: &[usize]) -> Vec<i8> {
         crate::ops::cmp::order::compare_idx(a, b, ia, ib)
+    }
+
+    // --- structural per-row content hash ---------------------------------------------------------
+    //
+    // A deterministic, position-independent u64 per row. The finalizer is splitmix64 and the
+    // fold `mix` is order-sensitive, so `Prod`/`List` element order matters while row POSITION,
+    // column capacity, and Arc identity do not. Distinct per-constructor seeds keep e.g. a `Unit`
+    // from colliding with a `Prim` that happens to carry the same bytes.
+
+    /// splitmix64 finalizer — a fast, seed-free avalanche used to mix leaf bytes and combine
+    /// child hashes reproducibly across processes (no `RandomState`).
+    #[inline]
+    fn splitmix64(mut z: u64) -> u64 {
+        z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// order-sensitive combine of an accumulator with the next child/leaf hash.
+    #[inline]
+    fn mix(h: u64, x: u64) -> u64 {
+        splitmix64(h ^ splitmix64(x))
+    }
+
+    // per-constructor seeds (arbitrary distinct constants; only their distinctness matters).
+    const SEED_PRIM: u64 = 0x0000_0000_5052_494D; // "PRIM"
+    const SEED_PROD: u64 = 0x0000_0000_5052_4F44; // "PROD"
+    const SEED_SUM: u64 = 0x0000_0000_0053_554D; //  "SUM"
+    const SEED_LIST: u64 = 0x0000_0000_4C49_5354; // "LIST"
+    const SEED_UNIT: u64 = 0x0000_0000_554E_4954; // "UNIT"
+
+    /// Structural content hash: `out[r]` is a stable u64 hash of row `r` of `v`, computed
+    /// columnar over the whole column in one pass. Kind-blind/structural: equal-by-`Value`-
+    /// equality rows hash equal, and the hash is a deterministic function of row CONTENT
+    /// (not of position or batch), so ids computed here coincide across the output->input
+    /// boundary of a dataflow operator. Returns a Vec<u64> aligned with `v`'s rows.
+    pub fn hash_rows(v: &Value) -> Vec<u64> {
+        match v {
+            // Leaf: mix the width tag into the seed (so different widths of the same numeric
+            // value need not collide), then avalanche each row's bytes read straight from the Vec.
+            Value::Prim(p) => {
+                let seed = SEED_PRIM.wrapping_add(p.bits() as u64);
+                match p {
+                    Prim::U8(xs) => xs.iter().map(|&x| mix(seed, x as u64)).collect(),
+                    Prim::U16(xs) => xs.iter().map(|&x| mix(seed, x as u64)).collect(),
+                    Prim::U32(xs) => xs.iter().map(|&x| mix(seed, x as u64)).collect(),
+                    Prim::U64(xs) => xs.iter().map(|&x| mix(seed, x)).collect(),
+                }
+            }
+            // Product: combine the child hashes of the row across all columns, in column order.
+            Value::Prod(cols) => {
+                let n = v.len();
+                let child: Vec<Vec<u64>> = cols.iter().map(hash_rows).collect();
+                (0..n)
+                    .map(|r| child.iter().fold(SEED_PROD, |h, c| mix(h, c[r])))
+                    .collect()
+            }
+            // Sum: mix the row's tag, then the committed lane's payload hash at the within-variant
+            // offset. A `None` lane holds no rows, so it is never indexed.
+            Value::Sum(tags, offset, variants) => {
+                let tags = tags.usize_vec();
+                let lanes: Vec<Option<Vec<u64>>> =
+                    variants.iter().map(|o| o.as_ref().map(hash_rows)).collect();
+                tags.iter()
+                    .zip(offset.iter())
+                    .map(|(&t, &o)| {
+                        let payload = lanes[t]
+                            .as_ref()
+                            .expect("hash_rows: row committed to a ⊥ lane")[o];
+                        mix(mix(SEED_SUM, t as u64), payload)
+                    })
+                    .collect()
+            }
+            // List: mix the row's element count, then the row's flattened element hashes in order.
+            Value::List(bounds, vals) => {
+                let elem = hash_rows(vals);
+                (0..bounds.len())
+                    .map(|r| {
+                        let (s, e) = bounds.span(r);
+                        let mut h = mix(SEED_LIST, (e - s) as u64);
+                        for k in s..e {
+                            h = mix(h, elem[k]);
+                        }
+                        h
+                    })
+                    .collect()
+            }
+            // Unit: every row is identical content, so a single constant.
+            Value::Unit(n) => vec![splitmix64(SEED_UNIT); *n],
+        }
+    }
+
+    #[cfg(test)]
+    mod hash_tests {
+        use super::hash_rows;
+        use crate::arrange::gather;
+        use crate::value::{Bounds, Value};
+        use std::sync::Arc;
+
+        #[test]
+        fn equal_and_single_diff() {
+            let a = Value::u32(vec![10, 20, 30, 40]);
+            let b = Value::u32(vec![10, 20, 30, 40]);
+            assert_eq!(hash_rows(&a), hash_rows(&b));
+
+            let c = Value::u32(vec![10, 20, 99, 40]);
+            let ha = hash_rows(&a);
+            let hc = hash_rows(&c);
+            assert_eq!(ha[0], hc[0]);
+            assert_eq!(ha[1], hc[1]);
+            assert_ne!(ha[2], hc[2]); // exactly the differing row changed
+            assert_eq!(ha[3], hc[3]);
+        }
+
+        #[test]
+        fn structural_stride_vs_offsets() {
+            // same logical list two ways: Stride(2,3) vs the equivalent Offsets([2,4,6]).
+            let vals = Value::u16(vec![1, 2, 3, 4, 5, 6]);
+            let strided = Value::List(Bounds::Stride(2, 3), Box::new(vals.clone()));
+            let offsets = Value::List(Bounds::Offsets(vec![2, 4, 6]), Box::new(vals));
+            assert_eq!(strided, offsets); // PartialEq-equal by the partition
+            assert_eq!(hash_rows(&strided), hash_rows(&offsets));
+        }
+
+        #[test]
+        fn ignores_arc_identity_and_capacity() {
+            // distinct Arcs, and an over-capacity backing Vec, must not change the hash.
+            let a = Value::u64(vec![7, 8, 9]);
+            let mut backing = Vec::with_capacity(64);
+            backing.extend_from_slice(&[7, 8, 9]);
+            let b = Value::Prim(crate::value::Prim::U64(Arc::new(backing)));
+            assert_eq!(hash_rows(&a), hash_rows(&b));
+        }
+
+        #[test]
+        fn covers_prim_prod_sum_list_unit() {
+            // Prod of a leaf and a nested Prod.
+            let leaf = Value::u8(vec![1, 2, 3]);
+            let nested = Value::Prod(vec![
+                Value::u16(vec![10, 20, 30]),
+                Value::u32(vec![100, 200, 300]),
+            ]);
+            let prod = Value::Prod(vec![leaf, nested]);
+            let hp = hash_rows(&prod);
+            assert_eq!(hp.len(), 3);
+            assert!(hp[0] != hp[1] && hp[1] != hp[2]);
+
+            // Sum with a ⊥/None lane (variant 0 uncommitted) and a multi-arm committed shape.
+            // tags: rows go to lane 1 (u16) and lane 2 (u32).
+            let s = Value::sum_opt(
+                vec![1, 2, 1, 2],
+                vec![
+                    None,
+                    Some(Value::u16(vec![5, 7])),
+                    Some(Value::u32(vec![9, 11])),
+                ],
+            );
+            let hs = hash_rows(&s);
+            assert_eq!(hs.len(), 4);
+            // rows 0 and 2 both land in lane 1 but carry different payloads → different hashes.
+            assert_ne!(hs[0], hs[2]);
+
+            // List with varying row widths.
+            let list = Value::List(
+                Bounds::Offsets(vec![2, 2, 5]), // rows of width 2, 0, 3
+                Box::new(Value::u8(vec![1, 2, 3, 4, 5])),
+            );
+            let hl = hash_rows(&list);
+            assert_eq!(hl.len(), 3);
+            assert_ne!(hl[0], hl[1]); // width-2 vs empty row differ
+            assert_ne!(hl[1], hl[2]);
+
+            // Unit: all rows identical.
+            let unit = Value::Unit(4);
+            let hu = hash_rows(&unit);
+            assert_eq!(hu.len(), 4);
+            assert!(hu.iter().all(|&x| x == hu[0]));
+        }
+
+        #[test]
+        fn empty_row_distinct_from_singleton_zero() {
+            // a width-0 list row must not hash like a row holding a single 0 element.
+            let list = Value::List(
+                Bounds::Offsets(vec![0, 1]),
+                Box::new(Value::u8(vec![0])),
+            );
+            let h = hash_rows(&list);
+            assert_ne!(h[0], h[1]);
+        }
+
+        #[test]
+        fn permutation_is_position_independent() {
+            // hash_rows(gather(v, perm))[k] == hash_rows(v)[perm[k]].
+            let v = Value::Prod(vec![
+                Value::u32(vec![3, 1, 4, 1, 5, 9]),
+                Value::u16(vec![30, 10, 40, 10, 50, 90]),
+            ]);
+            let perm = vec![5usize, 0, 3, 2, 1, 4];
+            let base = hash_rows(&v);
+            let permuted = hash_rows(&gather(&v, &perm));
+            for (k, &p) in perm.iter().enumerate() {
+                assert_eq!(permuted[k], base[p]);
+            }
+        }
     }
 }

--- a/corgi/src/lib.rs
+++ b/corgi/src/lib.rs
@@ -39,3 +39,55 @@ pub use ops::{dec_i64, enc_i64, ArithOp, BinOp, CmpOp, Kind, NumOp, Op, Pred, Re
 pub use optimize::{cancel_isos, cse, dce, fuse_maps, optimize, peephole};
 pub use shape::{shape_of_value, Shape};
 pub use value::{show, Bounds, Value};
+
+/// Arrangement-substrate support: row-level primitives for using corgi columns directly as a
+/// differential-dataflow batch (merge/sort/gather/compare over flat columns), without decoding
+/// to rows. Thin public wrappers over the internal `engine`/`ops::cmp::order` machinery. Added
+/// for the dd-corgi backend spike (Route B: cursor-less corgi arrangement).
+pub mod arrange {
+    use crate::value::{Bounds, Value};
+    use std::cmp::Ordering;
+
+    /// Batched equal-range probe (`find` as a single-row batch): for each row of `needles` (any
+    /// order), the `[lo, hi)` range of that key in the SORTED `haystack` column. Returns `(lo, hi)`
+    /// Vecs aligned with `needles`; `hi > lo` is the membership test, `lo..hi` the matching positions.
+    /// O(|needles| · log|haystack|) — the multi-record replacement for a per-pair merge-join /
+    /// semijoin scan.
+    pub fn find_ranges(needles: &Value, haystack: &Value) -> (Vec<usize>, Vec<usize>) {
+        let (n, h) = (needles.len(), haystack.len());
+        let needle_list = Value::List(Bounds::Offsets(vec![n]), Box::new(needles.clone()));
+        let hay_list = Value::List(Bounds::Offsets(vec![h]), Box::new(haystack.clone()));
+        let out = crate::ops::cmp::CmpOp::Find.eval(Value::Prod(vec![needle_list, hay_list]));
+        let (_b, vals) = out.into_list("find_ranges");
+        let (lo, hi) = vals.into_pair("find_ranges lo/hi");
+        let lo = lo.into_u64("find_ranges lo").into_iter().map(|x| x as usize).collect();
+        let hi = hi.into_u64("find_ranges hi").into_iter().map(|x| x as usize).collect();
+        (lo, hi)
+    }
+
+    /// Select/reorder rows of a single columnar `Value` by index.
+    pub fn gather(v: &Value, idx: &[usize]) -> Value { crate::engine::gather(v, idx) }
+    /// Multi-source gather: output row `i` = row `off[i]` of source `srcs[tags[i]]` (all same shape).
+    /// Builds a merged batch's columns by interleaving two sorted inputs without a concat.
+    pub fn gather_lanes(srcs: &[Option<&Value>], tags: &[usize], off: &[usize]) -> Value {
+        crate::engine::gather_lanes(srcs, tags, off)
+    }
+    /// Structural compare of row `i` of `a` vs row `j` of `b` (same shape). Build a sort by
+    /// `indices.sort_by(|&i,&j| compare_at(kv, i, kv, j))`; merge two sorted batches with it.
+    pub fn compare_at(a: &Value, i: usize, b: &Value, j: usize) -> Ordering {
+        crate::ops::cmp::order::compare_at(a, i, b, j)
+    }
+
+    /// Multi-record argsort: the permutation that sorts *all* of `v`'s rows by structural order, in
+    /// one columnar discrimination pass — the batched replacement for driving `sort_by(compare_at)`
+    /// per pair.
+    pub fn sort_perm(v: &Value) -> Vec<usize> {
+        crate::ops::cmp::order::sort_blocks(&vec![0u64; v.len()], v).0
+    }
+
+    /// Batched structural compare: `out[k]` = sign of row `ia[k]` of `a` vs row `ib[k]` of `b` (all
+    /// pairs in one pass). Use `ia=0..n-1`, `ib=1..n` to flag adjacent-equal runs after a sort.
+    pub fn compare_idx(a: &Value, b: &Value, ia: &[usize], ib: &[usize]) -> Vec<i8> {
+        crate::ops::cmp::order::compare_idx(a, b, ia, ib)
+    }
+}

--- a/corgi/src/lib.rs
+++ b/corgi/src/lib.rs
@@ -145,21 +145,6 @@ pub mod arrange {
         crate::ops::cmp::order::group_bounds(keys)
     }
 
-    /// Order rows by a leading `u64` discriminant `key` (a hash or value-id column) radix-first,
-    /// then refine `key`-equal rows by `v`'s structural order — hashing corgi columns as a
-    /// hash-ordered arrangement natively. Returns `(perm, labels)`: `perm` sorts into
-    /// `(key, structural(v))` order, and two output rows share a `labels` group iff they share a
-    /// `key` AND are structurally equal in `v`.
-    ///
-    /// `key` (e.g. [`hash_rows`]' output) is prepended as a real `u64` `CValue` leaf, so the
-    /// discrimination sort radixes it in one counting pass and descends into `v` only within
-    /// `key`-equal blocks — the blessed alternative to sorting a side `Vec<u64>` and gather-permuting
-    /// every column. The `labels` are the value-id / group seed a hash-ordered `present` scans in
-    /// order (no re-sort); pair with [`group_bounds`] / [`run_layout`] to read the group boundaries.
-    pub fn hash_order(key: &[u64], v: &Value) -> (Vec<usize>, Vec<u64>) {
-        crate::ops::cmp::order::hash_order(key, v)
-    }
-
     // --- structural per-row content hash ---------------------------------------------------------
     //
     // A deterministic, position-independent u64 per row. The finalizer is splitmix64 and the
@@ -368,8 +353,7 @@ pub mod arrange {
     #[cfg(test)]
     mod order_tests {
         use super::{
-            compare_at, gather, group_bounds, hash_order, run_layout, segment_labels, sort_blocks,
-            survey, Run,
+            compare_at, gather, group_bounds, run_layout, segment_labels, sort_blocks, survey, Run,
         };
         use crate::value::{Bounds, Value};
         use std::cmp::Ordering;
@@ -624,85 +608,6 @@ pub mod arrange {
             let keys = Value::u64(vec![10, 10, 20, 20, 20, 30]);
             let labels = vec![0u64, 0, 1, 1, 1, 2];
             assert_eq!(group_bounds(&keys), run_layout(&labels).0);
-        }
-
-        // --- hash_order (radix-leading discriminant) --------------------------------------------
-
-        /// Verify every guarantee [`hash_order`] promises: `perm` is a permutation ordered by
-        /// `(key, structural(v))`, and `labels` groups exactly the rows equal in both.
-        fn check_hash_order(key: &[u64], v: &Value) {
-            let n = v.len();
-            let (perm, labels) = hash_order(key, v);
-            assert_eq!(perm.len(), n);
-            assert_eq!(labels.len(), n);
-
-            // perm is a genuine permutation of 0..n.
-            let mut seen = perm.clone();
-            seen.sort_unstable();
-            assert_eq!(seen, (0..n).collect::<Vec<_>>(), "perm is not a permutation");
-
-            // ordered by (key, structural v); labels non-decreasing and grouping exactly the ties.
-            let sorted_v = gather(v, &perm);
-            assert!(labels.windows(2).all(|w| w[0] <= w[1]), "labels not non-decreasing");
-            for k in 1..n {
-                let (p0, p1) = (perm[k - 1], perm[k]);
-                let struct_eq = compare_at(&sorted_v, k - 1, &sorted_v, k) == Ordering::Equal;
-                let ord = if key[p0] != key[p1] {
-                    key[p0].cmp(&key[p1]) // key is primary
-                } else {
-                    compare_at(&sorted_v, k - 1, &sorted_v, k) // then structural
-                };
-                assert_ne!(ord, Ordering::Greater, "not in (key, structural) order at {k}");
-                // two rows share a label iff same key AND structurally equal.
-                let same_group = key[p0] == key[p1] && struct_eq;
-                assert_eq!(labels[k - 1] == labels[k], same_group, "label/group mismatch at {k}");
-            }
-        }
-
-        #[test]
-        fn hash_order_radix_leads_then_refines() {
-            // v's own leading field (9,9,1,1) DISAGREES with the hash order, so a correct result must
-            // be hash-primary, not structural-primary.
-            let v = Value::Prod(vec![
-                Value::u64(vec![9, 9, 1, 1]),
-                Value::u32(vec![0, 1, 0, 1]),
-            ]);
-            let key = vec![7u64, 9, 5, 5]; // hash order: rows {2,3} (5), {0} (7), {1} (9)
-            let (perm, labels) = hash_order(&key, &v);
-            // hash-5 block {2,3} refines by structural v: (1,0) < (1,1) → row 2 before row 3.
-            assert_eq!(perm, vec![2, 3, 0, 1]);
-            assert_eq!(labels, vec![0, 1, 2, 3]); // all four rows distinct in (key, v)
-            check_hash_order(&key, &v);
-        }
-
-        #[test]
-        fn hash_order_labels_are_collision_aware() {
-            // all rows collide on the hash → a single radix block, refined purely by structural v.
-            let v = Value::u64(vec![5, 5, 8]);
-            let key = vec![42u64, 42, 42];
-            let (perm, labels) = hash_order(&key, &v);
-            assert_eq!(gather(&v, &perm).into_u64("sv"), vec![5, 5, 8]);
-            assert_eq!(labels[0], labels[1]); // the two structurally-equal 5s are one group
-            assert_ne!(labels[1], labels[2]); // the 8 splits off, despite the shared hash
-            check_hash_order(&key, &v);
-        }
-
-        #[test]
-        fn hash_order_at_scale() {
-            // deterministic LCG (no rng dep): a small key space forces many hash collisions, so the
-            // structural refinement within radix blocks is genuinely exercised.
-            let n = 1000usize;
-            let (mut sk, mut sv) = (11u64, 22u64);
-            let mut keys = Vec::with_capacity(n);
-            let mut vals = Vec::with_capacity(n);
-            for _ in 0..n {
-                sk = sk.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-                sv = sv.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-                keys.push((sk >> 40) % 50); // ~20 rows per hash bucket
-                vals.push((sv >> 40) % 30);
-            }
-            let v = Value::Prod(vec![Value::u64(vals.clone()), Value::u32(keys.iter().map(|&k| k as u32).collect())]);
-            check_hash_order(&keys, &v);
         }
     }
 }

--- a/corgi/src/lib.rs
+++ b/corgi/src/lib.rs
@@ -124,6 +124,27 @@ pub mod arrange {
         crate::ops::cmp::order::run_layout(labels)
     }
 
+    pub use crate::ops::cmp::order::Run;
+
+    /// Survey the mutual interleaving of two structurally-sorted columns `a` and `b` as a sequence
+    /// of [`Run`]s — maximal ranges exclusive to one side, single matched pairs common to both — in
+    /// one bidirectional zig-zag gallop rather than a per-pair two-pointer. The bidirectional
+    /// generalization of [`find_ranges`] (the one-directional needle-into-haystack gallop), and the
+    /// merge kernel a `CorgiChunk` bulk-`gather`s its ranges from: the corgi/Rust boundary is crossed
+    /// once per *range*, not once per *row*, and corgi owns no times — the caller drives the lattice
+    /// consolidation off the returned runs. See [`Run`] for the coverage/sortedness guarantees.
+    pub fn survey(a: &Value, b: &Value) -> Vec<Run> {
+        crate::ops::cmp::order::survey(a, b)
+    }
+
+    /// Segment ends of the maximal equal-value runs in a structurally-sorted column `keys`:
+    /// `out[g]` is the exclusive end of group `g` (group `g` is `out[g-1]..out[g]`, implicit
+    /// `out[-1] = 0`), and `out.last() == keys.len()`. The single-column equal-key boundaries that
+    /// complement a [`survey`]; the `Value`-column analogue of [`run_layout`]'s `ends`.
+    pub fn group_bounds(keys: &Value) -> Vec<usize> {
+        crate::ops::cmp::order::group_bounds(keys)
+    }
+
     // --- structural per-row content hash ---------------------------------------------------------
     //
     // A deterministic, position-independent u64 per row. The finalizer is splitmix64 and the
@@ -331,8 +352,11 @@ pub mod arrange {
 
     #[cfg(test)]
     mod order_tests {
-        use super::{gather, run_layout, segment_labels, sort_blocks};
+        use super::{
+            compare_at, gather, group_bounds, run_layout, segment_labels, sort_blocks, survey, Run,
+        };
         use crate::value::{Bounds, Value};
+        use std::cmp::Ordering;
 
         #[test]
         fn sort_blocks_segmented_stable_argmin() {
@@ -398,6 +422,192 @@ pub mod arrange {
             // the ML op.
             let theirs = crate::ops::cmp::CmpOp::SortList.eval(list);
             assert_eq!(ours, theirs);
+        }
+
+        // --- survey / group_bounds ------------------------------------------------------------
+
+        /// The obvious O(n+m) oracle: the same zig-zag two-pointer as [`survey`] but with a linear
+        /// scan in place of the gallop, so it produces the identical `Run` structure element for
+        /// element — a direct check that galloping changes only cost, not the reported interleaving.
+        fn survey_naive(a: &Value, b: &Value) -> Vec<Run> {
+            let (na, nb) = (a.len(), b.len());
+            let (mut i, mut j) = (0usize, 0usize);
+            let mut out = Vec::new();
+            while i < na && j < nb {
+                match compare_at(a, i, b, j) {
+                    Ordering::Less => {
+                        let start = i;
+                        while i < na && compare_at(a, i, b, j) == Ordering::Less {
+                            i += 1;
+                        }
+                        out.push(Run::A(start, i));
+                    }
+                    Ordering::Equal => {
+                        out.push(Run::Both(i, j));
+                        i += 1;
+                        j += 1;
+                    }
+                    Ordering::Greater => {
+                        let start = j;
+                        while j < nb && compare_at(b, j, a, i) == Ordering::Less {
+                            j += 1;
+                        }
+                        out.push(Run::B(start, j));
+                    }
+                }
+            }
+            if i < na {
+                out.push(Run::A(i, na));
+            }
+            if j < nb {
+                out.push(Run::B(j, nb));
+            }
+            out
+        }
+
+        /// Check every guarantee [`survey`] promises, plus exact agreement with the linear oracle.
+        fn check_survey(a: &Value, b: &Value) {
+            let runs = survey(a, b);
+            assert_eq!(runs, survey_naive(a, b), "gallop must match the linear scan");
+
+            // 1. coverage: the A ranges and every Both.ia partition 0..a.len() in order (B likewise).
+            let (mut ai, mut bi) = (0usize, 0usize);
+            for r in &runs {
+                match *r {
+                    Run::A(lo, hi) => {
+                        assert_eq!(lo, ai, "gap/overlap in a coverage");
+                        assert!(lo < hi, "empty A run");
+                        ai = hi;
+                    }
+                    Run::B(lo, hi) => {
+                        assert_eq!(lo, bi, "gap/overlap in b coverage");
+                        assert!(lo < hi, "empty B run");
+                        bi = hi;
+                    }
+                    Run::Both(ia, ib) => {
+                        assert_eq!(ia, ai, "gap/overlap at a match (a side)");
+                        assert_eq!(ib, bi, "gap/overlap at a match (b side)");
+                        // 3. a match really is structurally equal.
+                        assert_eq!(compare_at(a, ia, b, ib), Ordering::Equal, "unequal Both");
+                        ai += 1;
+                        bi += 1;
+                    }
+                }
+            }
+            assert_eq!(ai, a.len(), "a not fully covered");
+            assert_eq!(bi, b.len(), "b not fully covered");
+
+            // 2. sortedness: expanding the runs to their rows yields a non-decreasing merge. Each
+            // emitted row is described as (side, index); consecutive rows must be <= structurally.
+            let mut rows: Vec<(bool, usize)> = Vec::new(); // (from_a, index)
+            for r in &runs {
+                match *r {
+                    Run::A(lo, hi) => rows.extend((lo..hi).map(|k| (true, k))),
+                    Run::B(lo, hi) => rows.extend((lo..hi).map(|k| (false, k))),
+                    Run::Both(ia, _) => rows.push((true, ia)),
+                }
+            }
+            for w in rows.windows(2) {
+                let side = |t: (bool, usize)| if t.0 { a } else { b };
+                let ord = compare_at(side(w[0]), w[0].1, side(w[1]), w[1].1);
+                assert_ne!(ord, Ordering::Greater, "merged sequence out of order");
+            }
+        }
+
+        #[test]
+        fn survey_disjoint_and_interleaved() {
+            // fully disjoint, a all below b: one A run then one B run.
+            assert_eq!(
+                survey(&Value::u64(vec![1, 2, 3]), &Value::u64(vec![4, 5, 6])),
+                vec![Run::A(0, 3), Run::B(0, 3)]
+            );
+            // strict interleave 1,2,3,4: alternating singleton runs, no matches.
+            assert_eq!(
+                survey(&Value::u64(vec![1, 3]), &Value::u64(vec![2, 4])),
+                vec![Run::A(0, 1), Run::B(0, 1), Run::A(1, 2), Run::B(1, 2)]
+            );
+            check_survey(&Value::u64(vec![1, 2, 3]), &Value::u64(vec![4, 5, 6]));
+            check_survey(&Value::u64(vec![1, 3]), &Value::u64(vec![2, 4]));
+        }
+
+        #[test]
+        fn survey_matches_and_gallop() {
+            // shared keys become Both; the long below-pivot stretches are what the gallop skips.
+            let a = Value::u64(vec![1, 2, 3, 4, 5]);
+            let b = Value::u64(vec![3, 5, 7]);
+            assert_eq!(
+                survey(&a, &b),
+                vec![Run::A(0, 2), Run::Both(2, 0), Run::A(3, 4), Run::Both(4, 1), Run::B(2, 3)]
+            );
+            check_survey(&a, &b);
+        }
+
+        #[test]
+        fn survey_duplicates_and_edges() {
+            // duplicate on one side after a match falls through as a follow-on A run.
+            check_survey(&Value::u64(vec![5, 5, 5]), &Value::u64(vec![5]));
+            check_survey(&Value::u64(vec![5]), &Value::u64(vec![5, 5, 5]));
+            // all equal, equal lengths: three Both pairs.
+            assert_eq!(
+                survey(&Value::u64(vec![7, 7]), &Value::u64(vec![7, 7])),
+                vec![Run::Both(0, 0), Run::Both(1, 1)]
+            );
+            // empty inputs.
+            assert_eq!(survey(&Value::u64(vec![]), &Value::u64(vec![1, 2])), vec![Run::B(0, 2)]);
+            assert_eq!(survey(&Value::u64(vec![1, 2]), &Value::u64(vec![])), vec![Run::A(0, 2)]);
+            assert!(survey(&Value::u64(vec![]), &Value::u64(vec![])).is_empty());
+        }
+
+        #[test]
+        fn survey_over_product_columns() {
+            // structural (key, val) rows: lexicographic order, some rows shared across the two runs.
+            let a = Value::Prod(vec![
+                Value::u64(vec![1, 1, 2, 3]),
+                Value::u32(vec![10, 20, 10, 10]),
+            ]);
+            let b = Value::Prod(vec![
+                Value::u64(vec![1, 2, 2, 4]),
+                Value::u32(vec![20, 10, 30, 10]),
+            ]);
+            // (1,20) and (2,10) are shared → two Both pairs; the rest interleave by lex order.
+            check_survey(&a, &b);
+            let runs = survey(&a, &b);
+            let both: Vec<_> = runs.iter().filter(|r| matches!(r, Run::Both(..))).collect();
+            assert_eq!(both, vec![&Run::Both(1, 0), &Run::Both(2, 1)]);
+        }
+
+        #[test]
+        fn survey_at_scale_matches_oracle() {
+            // two sorted runs drawn from an overlapping key space (deterministic LCG, no rng dep),
+            // exercising long gallop stretches and scattered matches against the linear oracle.
+            let mk = |seed: u64, n: usize, modulus: u64| {
+                let mut s = seed;
+                let mut xs: Vec<u64> = (0..n)
+                    .map(|_| {
+                        s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                        (s >> 33) % modulus
+                    })
+                    .collect();
+                xs.sort_unstable();
+                Value::u64(xs)
+            };
+            check_survey(&mk(1, 500, 300), &mk(2, 500, 300)); // dense overlap, many Both + dups
+            check_survey(&mk(3, 800, 5000), &mk(4, 200, 5000)); // sparse, lopsided sizes
+            check_survey(&mk(5, 1, 10), &mk(6, 1000, 10)); // single-element vs large
+        }
+
+        #[test]
+        fn group_bounds_runs() {
+            // exclusive ends of equal-value runs: [1,1,2,3,3,3] → groups [0,2),[2,3),[3,6).
+            assert_eq!(group_bounds(&Value::u64(vec![1, 1, 2, 3, 3, 3])), vec![2, 3, 6]);
+            // all distinct → one end per row; all equal → a single group; empty → no ends.
+            assert_eq!(group_bounds(&Value::u64(vec![1, 2, 3])), vec![1, 2, 3]);
+            assert_eq!(group_bounds(&Value::u64(vec![4, 4, 4])), vec![3]);
+            assert!(group_bounds(&Value::u64(vec![])).is_empty());
+            // agrees with run_layout's ends over the same value column read as its own labels.
+            let keys = Value::u64(vec![10, 10, 20, 20, 20, 30]);
+            let labels = vec![0u64, 0, 1, 1, 1, 2];
+            assert_eq!(group_bounds(&keys), run_layout(&labels).0);
         }
     }
 }

--- a/corgi/src/lib.rs
+++ b/corgi/src/lib.rs
@@ -91,6 +91,39 @@ pub mod arrange {
         crate::ops::cmp::order::compare_idx(a, b, ia, ib)
     }
 
+    /// Segmented (discrimination) argsort: the multi-block generalization of [`sort_perm`]. Given
+    /// per-row `labels` marking segments (non-decreasing — segment `s` is the maximal run of rows
+    /// sharing a label), return `(perm, refined_labels)` where `perm` sorts `v`'s rows WITHIN each
+    /// label block by corgi structural order (stable, so ties keep input order), and `refined_labels`
+    /// further splits each block by equal value (two rows share a refined label iff they shared a
+    /// `labels` value AND are structurally equal). `sort_perm(v)` is exactly the single-block case
+    /// `sort_blocks(&[0; n], v).0`.
+    ///
+    /// This is the load-bearing segmented primitive for the dd backend: within a segment `[lo, hi)`
+    /// (a run of one input label, read via [`run_layout`]), `perm[lo]` is the segment's structural
+    /// ARGMIN (its minimum row's original position) and `perm[lo..hi]` is the segment's sorted order —
+    /// so argmin/argmax/first-per-segment and per-segment sorted order fall out while keeping the row
+    /// positions the caller indexed by.
+    pub fn sort_blocks(labels: &[u64], v: &Value) -> (Vec<usize>, Vec<u64>) {
+        crate::ops::cmp::order::sort_blocks(labels, v)
+    }
+
+    /// Per-element segment labels from a `List`'s row `Bounds`: element of row `r` gets label `r`.
+    /// This is the seed for a segmented [`sort_blocks`] that sorts within each list row while keeping
+    /// the rows contiguous and in outer-row order. `Offsets` and the equivalent `Stride` produce the
+    /// same labels (labels depend only on the partition, not its encoding).
+    pub fn segment_labels(bounds: &Bounds) -> Vec<u64> {
+        crate::ops::cmp::order::segment_labels(bounds)
+    }
+
+    /// The run structure of a non-decreasing `labels` vector (e.g. either side of [`sort_blocks`]):
+    /// `(ends, firsts)`, where `ends[i]` is the exclusive end and `firsts[i]` the first index of the
+    /// `i`th maximal equal-label run. Reads segment/group boundaries back out — segment `i` occupies
+    /// `firsts[i]..ends[i]`, and `firsts` are the per-segment representative positions.
+    pub fn run_layout(labels: &[u64]) -> (Vec<usize>, Vec<usize>) {
+        crate::ops::cmp::order::run_layout(labels)
+    }
+
     // --- structural per-row content hash ---------------------------------------------------------
     //
     // A deterministic, position-independent u64 per row. The finalizer is splitmix64 and the
@@ -293,6 +326,78 @@ pub mod arrange {
             for (k, &p) in perm.iter().enumerate() {
                 assert_eq!(permuted[k], base[p]);
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod order_tests {
+        use super::{gather, run_layout, segment_labels, sort_blocks};
+        use crate::value::{Bounds, Value};
+
+        #[test]
+        fn sort_blocks_segmented_stable_argmin() {
+            // two segments (labels [0,0,0, 1,1,1]) over rows; segment 0 has duplicate 3s (stability),
+            // segment 1 has duplicate 5s. Segments must stay contiguous, sort within, argmin at start.
+            let labels = vec![0u64, 0, 0, 1, 1, 1];
+            let v = Value::u64(vec![3, 1, 3, 5, 2, 5]);
+            let (perm, _refined) = sort_blocks(&labels, &v);
+
+            // segment 0 occupies output [0,3), segment 1 [3,6); each perm entry stays in its segment's
+            // index range (rows contiguous, in segment order).
+            for &p in &perm[0..3] {
+                assert!(p < 3, "segment 0 pulled a row from segment 1");
+            }
+            for &p in &perm[3..6] {
+                assert!((3..6).contains(&p), "segment 1 pulled a row from segment 0");
+            }
+
+            // sorted WITHIN each segment.
+            let sorted = gather(&v, &perm).into_u64("sorted");
+            assert_eq!(&sorted[0..3], &[1, 3, 3]);
+            assert_eq!(&sorted[3..6], &[2, 5, 5]);
+
+            // perm[segment_start] is the segment's argmin (original position of its minimum).
+            assert_eq!(perm[0], 1); // min of [3,1,3] is at index 1
+            assert_eq!(perm[3], 4); // min of [5,2,5] is at index 4
+
+            // stability: the two equal 3s (indices 0 and 2) keep input order.
+            assert_eq!(&perm[1..3], &[0, 2]);
+        }
+
+        #[test]
+        fn segment_labels_offsets_and_stride_agree() {
+            // Offsets([2,4,6]) and the equivalent Stride(2,3) describe the same 3-row partition
+            // (rows of width 2), so per-element segment labels are identical.
+            let off = Bounds::Offsets(vec![2, 4, 6]);
+            let stride = Bounds::Stride(2, 3);
+            assert_eq!(segment_labels(&off), vec![0, 0, 1, 1, 2, 2]);
+            assert_eq!(segment_labels(&off), segment_labels(&stride));
+        }
+
+        #[test]
+        fn run_layout_simple() {
+            // labels [0,0,1,2,2] → 3 runs: [0,2), [2,3), [3,5).
+            let (ends, firsts) = run_layout(&[0, 0, 1, 2, 2]);
+            assert_eq!(ends, vec![2, 3, 5]);
+            assert_eq!(firsts, vec![0, 2, 3]);
+        }
+
+        #[test]
+        fn roundtrip_matches_sortlist_op() {
+            // build List<u64> with ragged rows, segmented-sort it via the arrange surface, and check
+            // it reproduces exactly what the ML `sort` op (CmpOp::SortList) produces on the same list.
+            let bounds = Bounds::Offsets(vec![3, 3, 6]); // rows [3,1,2], [], [5,0,4]
+            let vals = Value::u64(vec![3, 1, 2, 5, 0, 4]);
+            let list = Value::List(bounds.clone(), Box::new(vals.clone()));
+
+            // arrange surface: seed segment labels from bounds, segmented-sort, gather by perm.
+            let labels = segment_labels(&bounds);
+            let (perm, _refined) = sort_blocks(&labels, &vals);
+            let ours = Value::List(bounds.clone(), Box::new(gather(&vals, &perm)));
+
+            // the ML op.
+            let theirs = crate::ops::cmp::CmpOp::SortList.eval(list);
+            assert_eq!(ours, theirs);
         }
     }
 }

--- a/corgi/src/lib.rs
+++ b/corgi/src/lib.rs
@@ -145,6 +145,21 @@ pub mod arrange {
         crate::ops::cmp::order::group_bounds(keys)
     }
 
+    /// Order rows by a leading `u64` discriminant `key` (a hash or value-id column) radix-first,
+    /// then refine `key`-equal rows by `v`'s structural order — hashing corgi columns as a
+    /// hash-ordered arrangement natively. Returns `(perm, labels)`: `perm` sorts into
+    /// `(key, structural(v))` order, and two output rows share a `labels` group iff they share a
+    /// `key` AND are structurally equal in `v`.
+    ///
+    /// `key` (e.g. [`hash_rows`]' output) is prepended as a real `u64` `CValue` leaf, so the
+    /// discrimination sort radixes it in one counting pass and descends into `v` only within
+    /// `key`-equal blocks — the blessed alternative to sorting a side `Vec<u64>` and gather-permuting
+    /// every column. The `labels` are the value-id / group seed a hash-ordered `present` scans in
+    /// order (no re-sort); pair with [`group_bounds`] / [`run_layout`] to read the group boundaries.
+    pub fn hash_order(key: &[u64], v: &Value) -> (Vec<usize>, Vec<u64>) {
+        crate::ops::cmp::order::hash_order(key, v)
+    }
+
     // --- structural per-row content hash ---------------------------------------------------------
     //
     // A deterministic, position-independent u64 per row. The finalizer is splitmix64 and the
@@ -353,7 +368,8 @@ pub mod arrange {
     #[cfg(test)]
     mod order_tests {
         use super::{
-            compare_at, gather, group_bounds, run_layout, segment_labels, sort_blocks, survey, Run,
+            compare_at, gather, group_bounds, hash_order, run_layout, segment_labels, sort_blocks,
+            survey, Run,
         };
         use crate::value::{Bounds, Value};
         use std::cmp::Ordering;
@@ -608,6 +624,85 @@ pub mod arrange {
             let keys = Value::u64(vec![10, 10, 20, 20, 20, 30]);
             let labels = vec![0u64, 0, 1, 1, 1, 2];
             assert_eq!(group_bounds(&keys), run_layout(&labels).0);
+        }
+
+        // --- hash_order (radix-leading discriminant) --------------------------------------------
+
+        /// Verify every guarantee [`hash_order`] promises: `perm` is a permutation ordered by
+        /// `(key, structural(v))`, and `labels` groups exactly the rows equal in both.
+        fn check_hash_order(key: &[u64], v: &Value) {
+            let n = v.len();
+            let (perm, labels) = hash_order(key, v);
+            assert_eq!(perm.len(), n);
+            assert_eq!(labels.len(), n);
+
+            // perm is a genuine permutation of 0..n.
+            let mut seen = perm.clone();
+            seen.sort_unstable();
+            assert_eq!(seen, (0..n).collect::<Vec<_>>(), "perm is not a permutation");
+
+            // ordered by (key, structural v); labels non-decreasing and grouping exactly the ties.
+            let sorted_v = gather(v, &perm);
+            assert!(labels.windows(2).all(|w| w[0] <= w[1]), "labels not non-decreasing");
+            for k in 1..n {
+                let (p0, p1) = (perm[k - 1], perm[k]);
+                let struct_eq = compare_at(&sorted_v, k - 1, &sorted_v, k) == Ordering::Equal;
+                let ord = if key[p0] != key[p1] {
+                    key[p0].cmp(&key[p1]) // key is primary
+                } else {
+                    compare_at(&sorted_v, k - 1, &sorted_v, k) // then structural
+                };
+                assert_ne!(ord, Ordering::Greater, "not in (key, structural) order at {k}");
+                // two rows share a label iff same key AND structurally equal.
+                let same_group = key[p0] == key[p1] && struct_eq;
+                assert_eq!(labels[k - 1] == labels[k], same_group, "label/group mismatch at {k}");
+            }
+        }
+
+        #[test]
+        fn hash_order_radix_leads_then_refines() {
+            // v's own leading field (9,9,1,1) DISAGREES with the hash order, so a correct result must
+            // be hash-primary, not structural-primary.
+            let v = Value::Prod(vec![
+                Value::u64(vec![9, 9, 1, 1]),
+                Value::u32(vec![0, 1, 0, 1]),
+            ]);
+            let key = vec![7u64, 9, 5, 5]; // hash order: rows {2,3} (5), {0} (7), {1} (9)
+            let (perm, labels) = hash_order(&key, &v);
+            // hash-5 block {2,3} refines by structural v: (1,0) < (1,1) → row 2 before row 3.
+            assert_eq!(perm, vec![2, 3, 0, 1]);
+            assert_eq!(labels, vec![0, 1, 2, 3]); // all four rows distinct in (key, v)
+            check_hash_order(&key, &v);
+        }
+
+        #[test]
+        fn hash_order_labels_are_collision_aware() {
+            // all rows collide on the hash → a single radix block, refined purely by structural v.
+            let v = Value::u64(vec![5, 5, 8]);
+            let key = vec![42u64, 42, 42];
+            let (perm, labels) = hash_order(&key, &v);
+            assert_eq!(gather(&v, &perm).into_u64("sv"), vec![5, 5, 8]);
+            assert_eq!(labels[0], labels[1]); // the two structurally-equal 5s are one group
+            assert_ne!(labels[1], labels[2]); // the 8 splits off, despite the shared hash
+            check_hash_order(&key, &v);
+        }
+
+        #[test]
+        fn hash_order_at_scale() {
+            // deterministic LCG (no rng dep): a small key space forces many hash collisions, so the
+            // structural refinement within radix blocks is genuinely exercised.
+            let n = 1000usize;
+            let (mut sk, mut sv) = (11u64, 22u64);
+            let mut keys = Vec::with_capacity(n);
+            let mut vals = Vec::with_capacity(n);
+            for _ in 0..n {
+                sk = sk.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                sv = sv.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                keys.push((sk >> 40) % 50); // ~20 rows per hash bucket
+                vals.push((sv >> 40) % 30);
+            }
+            let v = Value::Prod(vec![Value::u64(vals.clone()), Value::u32(keys.iter().map(|&k| k as u32).collect())]);
+            check_hash_order(&keys, &v);
         }
     }
 }

--- a/corgi/src/ops/cmp.rs
+++ b/corgi/src/ops/cmp.rs
@@ -217,26 +217,28 @@ fn batched_bound(
     hi: &mut [usize],
     go_right: impl Fn(i8) -> bool,
 ) {
-    loop {
-        // live needles and their probe midpoints; the active list doubles as the needle indices
-        // (needle element k lives at index k in `nvals`).
-        let (mut active, mut mids) = (Vec::new(), Vec::new());
-        for (k, (&l, &h)) in lo.iter().zip(hi.iter()).enumerate() {
-            if l < h {
-                active.push(k);
-                mids.push((l + h) / 2);
-            }
-        }
-        if active.is_empty() {
-            break;
-        }
+    // The live needle set only shrinks: seed it once and compact in place each round, so a
+    // round's work tracks the ACTIVE needles, not all of them (the full rescan per round was
+    // ~8% of a join-heavy profile). `active` doubles as the needle indices into `nvals`.
+    let mut active: Vec<usize> = (0..lo.len()).filter(|&k| lo[k] < hi[k]).collect();
+    let mut mids: Vec<usize> = Vec::with_capacity(active.len());
+    while !active.is_empty() {
+        mids.clear();
+        mids.extend(active.iter().map(|&k| (lo[k] + hi[k]) / 2));
         let ord = compare_idx(hvals, nvals, &mids, &active);
-        for (t, &k) in active.iter().enumerate() {
+        let mut w = 0usize;
+        for t in 0..active.len() {
+            let k = active[t];
             if go_right(ord[t]) {
                 lo[k] = mids[t] + 1;
             } else {
                 hi[k] = mids[t];
             }
+            if lo[k] < hi[k] {
+                active[w] = k;
+                w += 1;
+            }
         }
+        active.truncate(w);
     }
 }

--- a/corgi/src/ops/cmp.rs
+++ b/corgi/src/ops/cmp.rs
@@ -5,7 +5,7 @@
 //! flat enum (no sub-graphs); `NumOp` embeds it as the `Cmp` bucket alongside `Core`/`Arith`.
 //! The structural-order engine these ops reduce to is the private [`order`] submodule.
 
-mod order;
+pub(crate) mod order;
 
 use crate::engine::gather;
 use order::{compare_cols, compare_idx, run_layout, runs_per_row, segment_labels, sort_blocks};

--- a/corgi/src/ops/cmp/order.rs
+++ b/corgi/src/ops/cmp/order.rs
@@ -162,14 +162,41 @@ mod compare {
             // leaf: read all pairs at their two indices in one width-dispatched pass.
             (Value::Prim(pa), Value::Prim(pb)) => pa.cmp_idx(ia, ib, pb),
 
-            // product = lexicographic: fold the fields (same pairs), each refining prior ties — keep
-            // the first field that broke the tie (the first nonzero sign).
+            // single-field product: the field's order IS the order — skip the fold + tie vec.
+            (Value::Prod(ca), Value::Prod(cb)) if ca.len() == 1 && cb.len() == 1 => {
+                compare_idx(&ca[0], &cb[0], ia, ib)
+            }
+
+            // product = lexicographic: field 0 over all pairs, then each later field over the
+            // SURVIVING TIES only — when an early field discriminates most pairs (the common
+            // case), later fields cost proportionally to the ties, not to m.
             (Value::Prod(ca), Value::Prod(cb)) => {
                 assert_eq!(ca.len(), cb.len(), "compare_idx: product arity");
-                let mut ord = vec![0i8; m];
-                for (x, y) in ca.iter().zip(cb) {
-                    for (o, c) in ord.iter_mut().zip(compare_idx(x, y, ia, ib)) {
-                        if *o == 0 { *o = c; }
+                let mut ord = compare_idx(&ca[0], &cb[0], ia, ib);
+                if ca.len() > 1 {
+                    let mut tie_k: Vec<usize> = (0..m).filter(|&k| ord[k] == 0).collect();
+                    let mut tia: Vec<usize> = tie_k.iter().map(|&k| ia[k]).collect();
+                    let mut tib: Vec<usize> = tie_k.iter().map(|&k| ib[k]).collect();
+                    for (x, y) in ca[1..].iter().zip(&cb[1..]) {
+                        if tie_k.is_empty() {
+                            break;
+                        }
+                        let sub = compare_idx(x, y, &tia, &tib);
+                        let mut w = 0usize;
+                        for t in 0..tie_k.len() {
+                            let k = tie_k[t];
+                            if sub[t] != 0 {
+                                ord[k] = sub[t];
+                            } else {
+                                tie_k[w] = k;
+                                tia[w] = tia[t];
+                                tib[w] = tib[t];
+                                w += 1;
+                            }
+                        }
+                        tie_k.truncate(w);
+                        tia.truncate(w);
+                        tib.truncate(w);
                     }
                 }
                 ord
@@ -361,23 +388,40 @@ mod discriminate {
     }
 
     fn sort_leaf_blocks(labels: &[u64], p: &Prim) -> (Vec<usize>, Vec<u64>) {
-        let mut perm = Vec::with_capacity(p.len());
-        let mut new_labels = Vec::with_capacity(p.len());
-        let mut next = 0u64;
+        // Per-block: stable byte-radix (or tiny-block insertion sort) IN PLACE over the perm
+        // slice, with one shared scratch — a refinement pass produces millions of tiny blocks,
+        // and per-block allocations (index collect + sort output + adjacent-compare vec) were
+        // ~17% self of a join-heavy profile. The adjacent compare runs ONCE over the whole
+        // column afterwards (one width dispatch), with block boundaries forcing label breaks.
+        let n = p.len();
+        let mut perm: Vec<usize> = Vec::with_capacity(n);
+        let mut ends: Vec<usize> = Vec::new();
+        let mut tmp: Vec<usize> = Vec::new();
         for (lo, hi) in find_blocks(labels) {
-            // stable byte-radix within the block (one comparator gone); a single `cmp_idx` over the
-            // adjacent pairs feeds the O(n) run-label scan — one width-dispatch, not one per element.
-            // Radix is stable, so the recursion stays stable — group keeps V-within-key order.
-            let sorted = p.sort_block(&(lo..hi).collect::<Vec<usize>>());
-            let adj = p.cmp_idx(&sorted[1..], &sorted[..sorted.len() - 1], p);
-            for (k, &i) in sorted.iter().enumerate() {
-                if k > 0 && adj[k - 1] != 0 {
-                    next += 1;
+            let start = perm.len();
+            perm.extend(lo..hi);
+            if hi - lo > 1 {
+                p.sort_block_scratch(&mut perm[start..], &mut tmp);
+            }
+            ends.push(perm.len());
+        }
+        let mut new_labels = Vec::with_capacity(n);
+        if n > 0 {
+            let adj = if n > 1 { p.cmp_idx(&perm[1..], &perm[..n - 1], p) } else { Vec::new() };
+            let mut next = 0u64;
+            let mut b = 0usize;
+            for k in 0..n {
+                if k > 0 {
+                    let boundary = ends[b] == k;
+                    if boundary {
+                        b += 1;
+                    }
+                    if boundary || adj[k - 1] != 0 {
+                        next += 1;
+                    }
                 }
                 new_labels.push(next);
-                perm.push(i);
             }
-            next += 1;
         }
         (perm, new_labels)
     }

--- a/corgi/src/ops/cmp/order.rs
+++ b/corgi/src/ops/cmp/order.rs
@@ -133,29 +133,6 @@ pub fn group_bounds(keys: &Value) -> Vec<usize> {
     ends
 }
 
-/// Order rows by a leading `u64` discriminant `key` (a hash or value-id column) radix-first, then
-/// refine `key`-equal rows by `v`'s structural order — the "hash as a leading `CValue` column"
-/// arrangement order. Returns `(perm, labels)`: `perm` sorts the rows into `(key, structural(v))`
-/// order, and `labels[k]` is the group of output row `k` — two output rows share a label iff they
-/// share a `key` AND are structurally equal in `v`. Positions-returning; owns no times.
-///
-/// `key` is prepended as a genuine `u64` leaf column, so the discrimination sort radixes it in one
-/// counting pass (high all-zero bytes skipped) and descends into `v` only within each `key`-equal
-/// block — with a 64-bit hash those blocks are almost all singletons, so the structural refinement
-/// is near-free. This is the blessed alternative to sorting a side `Vec<u64>` and gather-permuting
-/// every column (which regresses to a full sort + a per-column gather).
-///
-/// The pure-`key` order (no structural refinement) is just a leaf sort of `Value::u64(key)`; the
-/// refined `labels` here are the value-id / group seed a hash-ordered `present` scans in order (no
-/// re-sort) and that [`group_bounds`] / [`run_layout`] read.
-pub fn hash_order(key: &[u64], v: &Value) -> (Vec<usize>, Vec<u64>) {
-    let n = v.len();
-    debug_assert_eq!(key.len(), n);
-    // the leading discriminant as a real CValue leaf → `sort_prod_blocks` radixes it, then refines.
-    let keyed = Value::Prod(vec![Value::u64(key.to_vec()), v.clone()]);
-    sort_blocks(&vec![0u64; n], &keyed)
-}
-
 mod compare {
     //! The bulk structural comparator: a total structural order on rows, recursing through the type —
     //! leaf value, then Prod field-by-field, List LENGTH-FIRST (shorter first; equal lengths element-wise),

--- a/corgi/src/ops/cmp/order.rs
+++ b/corgi/src/ops/cmp/order.rs
@@ -133,6 +133,29 @@ pub fn group_bounds(keys: &Value) -> Vec<usize> {
     ends
 }
 
+/// Order rows by a leading `u64` discriminant `key` (a hash or value-id column) radix-first, then
+/// refine `key`-equal rows by `v`'s structural order — the "hash as a leading `CValue` column"
+/// arrangement order. Returns `(perm, labels)`: `perm` sorts the rows into `(key, structural(v))`
+/// order, and `labels[k]` is the group of output row `k` — two output rows share a label iff they
+/// share a `key` AND are structurally equal in `v`. Positions-returning; owns no times.
+///
+/// `key` is prepended as a genuine `u64` leaf column, so the discrimination sort radixes it in one
+/// counting pass (high all-zero bytes skipped) and descends into `v` only within each `key`-equal
+/// block — with a 64-bit hash those blocks are almost all singletons, so the structural refinement
+/// is near-free. This is the blessed alternative to sorting a side `Vec<u64>` and gather-permuting
+/// every column (which regresses to a full sort + a per-column gather).
+///
+/// The pure-`key` order (no structural refinement) is just a leaf sort of `Value::u64(key)`; the
+/// refined `labels` here are the value-id / group seed a hash-ordered `present` scans in order (no
+/// re-sort) and that [`group_bounds`] / [`run_layout`] read.
+pub fn hash_order(key: &[u64], v: &Value) -> (Vec<usize>, Vec<u64>) {
+    let n = v.len();
+    debug_assert_eq!(key.len(), n);
+    // the leading discriminant as a real CValue leaf → `sort_prod_blocks` radixes it, then refines.
+    let keyed = Value::Prod(vec![Value::u64(key.to_vec()), v.clone()]);
+    sort_blocks(&vec![0u64; n], &keyed)
+}
+
 mod compare {
     //! The bulk structural comparator: a total structural order on rows, recursing through the type —
     //! leaf value, then Prod field-by-field, List LENGTH-FIRST (shorter first; equal lengths element-wise),

--- a/corgi/src/ops/cmp/order.rs
+++ b/corgi/src/ops/cmp/order.rs
@@ -9,6 +9,17 @@ use std::cmp::Ordering;
 pub(crate) use compare::*;
 pub(crate) use discriminate::*;
 
+/// Scalar structural compare: row `i` of `a` vs row `j` of `b` (same shape). The merge/search
+/// scalar form of [`compare_idx`]; exposed (via `crate::arrange`) for using corgi columns as a
+/// differential-dataflow arrangement substrate.
+pub(crate) fn compare_at(a: &Value, i: usize, b: &Value, j: usize) -> Ordering {
+    match compare_idx(a, b, &[i], &[j])[0] {
+        s if s < 0 => Ordering::Less,
+        0 => Ordering::Equal,
+        _ => Ordering::Greater,
+    }
+}
+
 mod compare {
     //! The bulk structural comparator: a total structural order on rows, recursing through the type —
     //! leaf value, then Prod field-by-field, List LENGTH-FIRST (shorter first; equal lengths element-wise),
@@ -106,6 +117,10 @@ mod compare {
                 }
                 ord
             }
+
+            // Unit rows carry no payload — always equal. (Added for `crate::arrange`: a unit-valued
+            // column, e.g. `distinct`'s output, must be a sortable arrangement payload.)
+            (Value::Unit(_), Value::Unit(_)) => vec![0i8; ia.len()],
 
             _ => panic!("compare_idx: shape mismatch"),
         }

--- a/corgi/src/ops/cmp/order.rs
+++ b/corgi/src/ops/cmp/order.rs
@@ -20,6 +20,119 @@ pub(crate) fn compare_at(a: &Value, i: usize, b: &Value, j: usize) -> Ordering {
     }
 }
 
+/// One report from [`survey`]: a maximal range drawn from one side of the interleaving, or a
+/// single matched pair present in both. The bidirectional generalization of `find_ranges`' report.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Run {
+    /// Rows `a[lo..hi)` come next in merged order, all strictly less than the current head of `b`
+    /// (exclusive to `a` over this range).
+    A(usize, usize),
+    /// Rows `b[lo..hi)` come next in merged order, all strictly less than the current head of `a`
+    /// (exclusive to `b` over this range).
+    B(usize, usize),
+    /// A single matched pair: row `a[ia]` and row `b[ib]` are structurally equal.
+    Both(usize, usize),
+}
+
+/// Galloping search over the structurally-sorted column `xs`: advance `*idx` (bounded by `hi`)
+/// while row `*idx` of `xs` compares strictly less than row `pj` of `piv`. On return `*idx` is the
+/// first position whose row is `>= piv[pj]` (or `hi`). Exponential probe + binary refine, so it
+/// costs `O(log gap)` `compare_at`s rather than one per row — the whole point of the survey.
+fn gallop_lt(xs: &Value, idx: &mut usize, hi: usize, piv: &Value, pj: usize) {
+    let lt = |k: usize| compare_at(xs, k, piv, pj) == Ordering::Less;
+    // nothing to do unless the row at the cursor is itself still below the pivot.
+    if *idx < hi && lt(*idx) {
+        let mut step = 1;
+        while *idx + step < hi && lt(*idx + step) {
+            *idx += step;
+            step <<= 1;
+        }
+        // binary refine over the last (overshot) doubling.
+        step >>= 1;
+        while step > 0 {
+            if *idx + step < hi && lt(*idx + step) {
+                *idx += step;
+            }
+            step >>= 1;
+        }
+        // `*idx` sits on the last row `< piv`; step past it to the first row `>= piv`.
+        *idx += 1;
+    }
+}
+
+/// Survey the mutual interleaving of two structurally-sorted columns `a` and `b`: a zig-zag gallop
+/// that returns the merge as a sequence of [`Run`]s — maximal ranges exclusive to one side and the
+/// single matched pairs present in both — instead of a per-pair two-pointer. The bidirectional
+/// generalization of `find_ranges` (the one-directional needle-into-haystack gallop).
+///
+/// The caller bulk-`gather`s each `A`/`B` range and consolidates only at the `Both` pairs, so the
+/// merge crosses the corgi/Rust boundary once per *range* rather than once per *row*. This owns no
+/// times/diffs: it reports only positions, and the caller drives its own lattice logic off the runs.
+///
+/// Guarantees: the `A` ranges plus every `Both`'s `ia` cover `0..a.len()` in order with no gap or
+/// overlap (`b` likewise via `hi`/`ib`); expanding the runs to their rows yields a non-decreasing
+/// structural sequence; every `Both(ia, ib)` has `compare_at(a, ia, b, ib) == Equal`. Equal
+/// duplicates within one side after the match fall through as follow-on `A`/`B` runs (as in DD's
+/// `trie_merger::survey`, the reference this ports).
+pub fn survey(a: &Value, b: &Value) -> Vec<Run> {
+    let (na, nb) = (a.len(), b.len());
+    let (mut i, mut j) = (0usize, 0usize);
+    let mut out = Vec::new();
+    while i < na && j < nb {
+        match compare_at(a, i, b, j) {
+            Ordering::Less => {
+                let start = i;
+                i += 1;
+                gallop_lt(a, &mut i, na, b, j); // a[start..i) all < b[j]
+                out.push(Run::A(start, i));
+            }
+            Ordering::Equal => {
+                out.push(Run::Both(i, j));
+                i += 1;
+                j += 1;
+            }
+            Ordering::Greater => {
+                let start = j;
+                j += 1;
+                gallop_lt(b, &mut j, nb, a, i); // b[start..j) all < a[i]
+                out.push(Run::B(start, j));
+            }
+        }
+    }
+    // one side exhausted: the remainder of the other is a single trailing run.
+    if i < na {
+        out.push(Run::A(i, na));
+    }
+    if j < nb {
+        out.push(Run::B(j, nb));
+    }
+    out
+}
+
+/// Segment ends of the maximal equal-value runs in a structurally-sorted column `keys`: `out[g]` is
+/// the exclusive end of group `g`, so group `g` occupies `out[g-1]..out[g]` (with an implicit
+/// `out[-1] = 0`) and `out.last() == keys.len()`. One columnar adjacent-compare pass — the
+/// single-column analogue of the equal-key boundaries a [`survey`] reveals across two runs, and the
+/// `Value`-column counterpart of [`run_layout`]'s `ends` (which reads a precomputed labels vector).
+pub fn group_bounds(keys: &Value) -> Vec<usize> {
+    let n = keys.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    // signs[k] = order of keys[k] vs keys[k+1]; a nonzero sign is a group boundary after k.
+    let ia: Vec<usize> = (0..n - 1).collect();
+    let ib: Vec<usize> = (1..n).collect();
+    let signs = compare_idx(keys, keys, &ia, &ib);
+    let mut ends = Vec::new();
+    for (k, &s) in signs.iter().enumerate() {
+        if s != 0 {
+            ends.push(k + 1);
+        }
+    }
+    ends.push(n);
+    ends
+}
+
 mod compare {
     //! The bulk structural comparator: a total structural order on rows, recursing through the type —
     //! leaf value, then Prod field-by-field, List LENGTH-FIRST (shorter first; equal lengths element-wise),

--- a/corgi/src/ops/core.rs
+++ b/corgi/src/ops/core.rs
@@ -504,6 +504,23 @@ impl<L: OpLike> Op<L> {
             Op::Fold(body) => {
                 let (seed, list) = input.into_pair("Fold");
                 let (bounds, vals) = list.into_list("Fold list");
+                // Strided fast path: every row has length k, so every row is active in every
+                // round — no worklist, no per-round accumulator gather/scatter (the whole
+                // accumulator IS the active set); one strided element gather per round.
+                if let Some(k) = bounds.strided() {
+                    let n = bounds.len();
+                    let mut acc = seed;
+                    let mut elem: Vec<usize> = Vec::with_capacity(n);
+                    for t in 0..k {
+                        elem.clear();
+                        elem.extend((0..n).map(|r| r * k + t));
+                        let elt = gather(&vals, &elem);
+                        let updated = eval_graph(body, Value::Prod(vec![acc, elt]));
+                        assert_eq!(updated.len(), n, "Fold body changed the row count");
+                        acc = updated;
+                    }
+                    return acc;
+                }
                 let mut acc = seed;
                 let mut active = init_active(&bounds);
                 let mut t = 0;
@@ -527,6 +544,37 @@ impl<L: OpLike> Op<L> {
                 let (seed, list) = input.into_pair("FoldScan");
                 let (bounds, vals) = list.into_list("FoldScan list");
                 let total = vals.len();
+                // Strided fast path — as in `Fold`: no worklist, no scatter; round t's outputs
+                // land at positions r*k + t, chunk t, slot r.
+                if let Some(k) = bounds.strided() {
+                    let n = bounds.len();
+                    let mut acc = seed;
+                    let mut chunks: Vec<Value> = Vec::with_capacity(k);
+                    let (mut tags, mut off) = (vec![0usize; total], vec![0usize; total]);
+                    let mut elem: Vec<usize> = Vec::with_capacity(n);
+                    for t in 0..k {
+                        elem.clear();
+                        elem.extend((0..n).map(|r| r * k + t));
+                        let elt = gather(&vals, &elem);
+                        let (new_state, r) =
+                            eval_graph(body, Value::Prod(vec![acc, elt])).into_pair("FoldScan body");
+                        assert_eq!(new_state.len(), n, "FoldScan body changed the row count");
+                        for (slot, &pos) in elem.iter().enumerate() {
+                            tags[pos] = t;
+                            off[pos] = slot;
+                        }
+                        acc = new_state;
+                        chunks.push(r);
+                    }
+                    let out_vals = if chunks.is_empty() {
+                        let z = eval_graph(body, Value::Prod(vec![gather(&acc, &[]), gather(&vals, &[])]));
+                        z.into_pair("FoldScan body").1
+                    } else {
+                        let refs: Vec<Option<&Value>> = chunks.iter().map(Some).collect();
+                        gather_lanes(&refs, &tags, &off)
+                    };
+                    return Value::Prod(vec![acc, Value::List(bounds, Box::new(out_vals))]);
+                }
                 let mut acc = seed;
                 let mut chunks: Vec<Value> = Vec::new();
                 let (mut tags, mut off) = (vec![0usize; total], vec![0usize; total]);

--- a/corgi/src/ops/numeric.rs
+++ b/corgi/src/ops/numeric.rs
@@ -265,8 +265,11 @@ impl ArithOp {
                 for end in bounds.ends() {
                     let s = &xs[start..end]; // empty row -> the monoid identity
                     out.push(match r {
-                        Red::Add => s.iter().sum(),
-                        Red::Mul => s.iter().product(),
+                        // Wrapping, to match the Scan sibling (prefix!) and the Kind::U BinOp add — so
+                        // reducing raw two's-complement diffs (a negative diff is a large u64) yields
+                        // the correct i64 sum instead of a checked-overflow panic in debug.
+                        Red::Add => s.iter().fold(0u64, |a, &x| a.wrapping_add(x)),
+                        Red::Mul => s.iter().fold(1u64, |a, &x| a.wrapping_mul(x)),
                         Red::Min => s.iter().copied().min().unwrap_or(u64::MAX),
                         Red::Max => s.iter().copied().max().unwrap_or(0),
                         Red::All => s.iter().all(|&x| x != 0) as u64,

--- a/corgi/src/value.rs
+++ b/corgi/src/value.rs
@@ -85,6 +85,18 @@ impl Bounds {
 
 impl From<Vec<usize>> for Bounds {
     fn from(v: Vec<usize>) -> Self {
+        // One O(n) uniformity check at construction: a uniform partition becomes a `Stride`,
+        // so `strided()` recovers the array kernels downstream at every `.into()` site for
+        // free. Equality/hash are by the partition, so this is representation-invisible.
+        if let Some(&last) = v.last() {
+            let n = v.len();
+            if last % n == 0 {
+                let k = last / n;
+                if v.iter().enumerate().all(|(i, &e)| e == (i + 1) * k) {
+                    return Bounds::Stride(k, n);
+                }
+            }
+        }
         Bounds::Offsets(v)
     }
 }
@@ -235,40 +247,71 @@ macro_rules! prim {
                 }
             }
 
-            /// stable LSD byte-radix: `indices` reordered by leaf value. A counting sort
-            /// per *significant* byte (high all-zero bytes skipped), so narrow values and
-            /// narrow widths are cheap — a `u8` column is one counting pass.
-            pub(crate) fn sort_block(&self, indices: &[usize]) -> Vec<usize> {
+            /// stable LSD byte-radix over a mutable index slice, IN PLACE (`tmp` is caller
+            /// scratch, resized as needed and reusable across calls — a refinement pass calls
+            /// this once per block, and per-block allocations dominated a join-heavy profile).
+            /// A counting sort per *significant* byte (high all-zero bytes skipped); blocks of
+            /// <= 16 take a stable insertion sort instead — the radix set-up dwarfs tiny
+            /// blocks, the common case once a prior pass has split the column into groups.
+            pub(crate) fn sort_block_scratch(&self, idx: &mut [usize], tmp: &mut Vec<usize>) {
                 match self {
                     $( Prim::$V(v) => {
-                        let mut cur = indices.to_vec();
-                        if cur.len() <= 1 {
-                            return cur;
+                        let n = idx.len();
+                        if n <= 1 {
+                            return;
                         }
-                        let max = cur.iter().map(|&i| v[i]).max().unwrap_or(0);
+                        if n <= 16 {
+                            for k in 1..n {
+                                let mut j = k;
+                                while j > 0 && v[idx[j - 1]] > v[idx[j]] {
+                                    idx.swap(j - 1, j);
+                                    j -= 1;
+                                }
+                            }
+                            return;
+                        }
+                        let max = idx.iter().map(|&i| v[i]).max().unwrap_or(0);
                         let bits = std::mem::size_of::<$t>() * 8;
                         let nbytes = (bits - max.leading_zeros() as usize).div_ceil(8);
-                        let mut tmp = vec![0usize; cur.len()];
+                        if tmp.len() < n {
+                            tmp.resize(n, 0);
+                        }
+                        let mut src_is_idx = true;
                         for byte in 0..nbytes {
                             let shift = (byte * 8) as u32;
                             let mut counts = [0usize; 256];
-                            for &i in &cur {
-                                counts[((v[i] >> shift) & 0xff) as usize] += 1;
+                            {
+                                let src: &[usize] = if src_is_idx { &idx[..] } else { &tmp[..n] };
+                                for &i in src {
+                                    counts[((v[i] >> shift) & 0xff) as usize] += 1;
+                                }
                             }
                             let mut start = 0;
                             for c in counts.iter_mut() {
-                                let n = *c;
+                                let cnt = *c;
                                 *c = start;
-                                start += n;
+                                start += cnt;
                             }
-                            for &i in &cur {
-                                let b = ((v[i] >> shift) & 0xff) as usize;
-                                tmp[counts[b]] = i;
-                                counts[b] += 1;
+                            if src_is_idx {
+                                for k in 0..n {
+                                    let i = idx[k];
+                                    let b = ((v[i] >> shift) & 0xff) as usize;
+                                    tmp[counts[b]] = i;
+                                    counts[b] += 1;
+                                }
+                            } else {
+                                for k in 0..n {
+                                    let i = tmp[k];
+                                    let b = ((v[i] >> shift) & 0xff) as usize;
+                                    idx[counts[b]] = i;
+                                    counts[b] += 1;
+                                }
                             }
-                            std::mem::swap(&mut cur, &mut tmp);
+                            src_is_idx = !src_is_idx;
                         }
-                        cur
+                        if !src_is_idx {
+                            idx.copy_from_slice(&tmp[..n]);
+                        }
                     } )+
                 }
             }


### PR DESCRIPTION
Brings 8 commits (~895 insertions, all under `corgi/`) onto master. This is the substrate the DDIR corgi backend is built on, and it is currently reachable only from a side branch — DDIR pins the rev `1301b281`, which exists on no other ref. Landing it means DDIR can pin master.

**Merges cleanly** (merge-tree reports zero conflicts; master has moved only in `sprig/` and `hobbes-precis.md` since the 07-03 split). **Tests green**: 69 passing on the branch.

### What it adds — one module, `corgi::arrange`

Thin public wrappers over the internal `engine` / `ops::cmp::order` machinery, so corgi columns can serve directly as a differential-dataflow batch without decoding to rows:

- **probe/search**: `find_ranges` (batched equal-range), `group_bounds`
- **merge alignment**: `survey` (bidirectional gallop reporting exclusive ranges and overlaps)
- **gather**: `gather`, `gather_lanes`
- **compare/sort**: `compare_at`, `compare_idx`, `sort_perm`, `sort_blocks`, `segment_labels`, `run_layout`
- **identity**: `hash_rows` (structural per-row content hash to a stable `u64`)

Plus supporting work in `ops/cmp`, `ops/core`, `ops/numeric` (Reduce Add/Mul wrapping, to match `Scan` and `Kind::U`) and `value.rs`.

### Two things a reviewer should know

1. **The history contains an add-and-revert pair** — `c06bb9d` "arrange: hash_order — radix by a leading u64 discriminant" and `f556868` reverting it the next day. Left as an honest record; squash if you would rather it not land.

2. **`survey_groups` is deliberately not here.** It exists on `fable/work` (`1ece187`) and did not make the `Land/kernels` squash; the branches are otherwise content-identical (`cmp.rs`, `core.rs`, `value.rs` byte-for-byte, verified). Not landing it looks *right* rather than accidental: an architecture review argued it solves the layered-merge problem the wrong way — a wider `Both` instead of a **scoped** survey taking prior-layer reports, which is the shape DD's own `trie_merger::merge_pair` already uses to recurse key to val to time. If that argument holds, `survey_groups` should be superseded rather than landed.

### Follow-on

PR #8 sits on top of this branch: a native `u64` path for `find_ranges` (**−20% scc, −26% reach** steady-state, measured against this exact base) plus a `leaf_slice` borrow accessor. Merging this first makes that one a small diff against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
